### PR TITLE
ci: repeat ci workflow on push to master

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,11 +19,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
   apply:
     name: Apply
     runs-on: ubuntu-latest
-
     environment: global
+    needs: [ci]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   merge_group:
     types: [checks_requested]
+  workflow_call:
 
 permissions:
   actions: read
@@ -52,9 +53,7 @@ jobs:
   plan:
     name: Plan
     runs-on: ubuntu-latest
-
-    needs:
-      - validate
+    needs: [validate]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
CD is failing because GitHub artifacts cannot be shared between workflows (or at least not in a straightforward way). We don't have an artifact repository yet and GitHub releases seem like the wrong thing to use for the Terraform plans (or are they?).